### PR TITLE
Fix spacing and formatting for username +  date in a review

### DIFF
--- a/Civility Optics/Networking/NetworkingService.swift
+++ b/Civility Optics/Networking/NetworkingService.swift
@@ -390,6 +390,7 @@ struct Review: Codable, Hashable {
   var value: Double
   var tags: [String] 
   var date_visited: String
+  var user_name: String
 }
 
 struct AnyEncodable: Encodable {

--- a/Civility Optics/Views/VenueDetails.swift
+++ b/Civility Optics/Views/VenueDetails.swift
@@ -6,7 +6,7 @@
 // additions by Parkarajot Singh on 04/9/22
 
 import SwiftUI
-
+import Foundation
 @available(iOS 14.0, *)
 struct VenueDetails: View {
   
@@ -77,6 +77,16 @@ var email: String
           HStack {
             VStack {
                 HStack(spacing: 4) {
+                    // Convert Date to String
+                    // Create Date Formatter
+                    let endOfSentence = result.date_visited.firstIndex(of: "T")!
+                    let date = result.date_visited[...endOfSentence]
+                    Text(date)
+                    Spacer()
+                }
+                HStack(spacing: 4) {
+                    // Convert Date to String
+                    // Create Date Formatter
                     Text("Rating: ")
                         .bold()
 //                        .multilineTextAlignment(.leading)

--- a/Civility Optics/Views/VenueDetails.swift
+++ b/Civility Optics/Views/VenueDetails.swift
@@ -82,11 +82,13 @@ var email: String
                     // Create Date Formatter
                     let endOfSentence = result.date_visited.firstIndex(of: "T")!
                     let date = result.date_visited[...endOfSentence]
-                    Text(date)
+                    Text(date).font(.caption)
                     Spacer()
                 }
                 HStack(spacing: 4) {
-                    Text(result.user_name)
+                    let reviewer = "by " + result.user_name
+                    Text(reviewer).font(.caption)
+                    Spacer()
                 }
                 }
                 HStack(spacing: 4) {

--- a/Civility Optics/Views/VenueDetails.swift
+++ b/Civility Optics/Views/VenueDetails.swift
@@ -76,6 +76,7 @@ var email: String
         ForEach(model.results, id: \.self) { result in
           HStack {
             VStack {
+                Group{
                 HStack(spacing: 4) {
                     // Convert Date to String
                     // Create Date Formatter
@@ -83,6 +84,10 @@ var email: String
                     let date = result.date_visited[...endOfSentence]
                     Text(date)
                     Spacer()
+                }
+                HStack(spacing: 4) {
+                    Text(result.user_name)
+                }
                 }
                 HStack(spacing: 4) {
                     // Convert Date to String


### PR DESCRIPTION
The username and date now appear as smaller text than the rating as review, and are aligned properly.
Collaborators: Parkaranjot Singh and Madhura